### PR TITLE
Add "none" wireless software

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ EOF
 | 🏠 **Host** | Router IP address | - | Any valid IP address |
 | 👤 **Username** | Login username | - | Usually 'root' |
 | 🔑 **Password** | Login password | - | Router admin password |
-| 📡 **Wireless Software** | Wireless monitoring method | iwinfo | iwinfo, hostapd |
+| 📡 **Wireless Software** | Wireless monitoring method | iwinfo | iwinfo, hostapd, none |
 | 🌐 **DHCP Software** | DHCP client detection | dnsmasq | dnsmasq, odhcpd, none |
 | ⏱️ **System Timeout** | System data fetch timeout | 30s | 5s-300s |
 | 📊 **QModem Timeout** | QModem data fetch timeout | 30s | 5s-300s |

--- a/custom_components/openwrt_ubus/const.py
+++ b/custom_components/openwrt_ubus/const.py
@@ -11,7 +11,7 @@ CONF_WIRELESS_SOFTWARE = "wireless_software"
 DEFAULT_DHCP_SOFTWARE = "dnsmasq"
 DEFAULT_WIRELESS_SOFTWARE = "iwinfo"
 DHCP_SOFTWARES = ["dnsmasq", "odhcpd", "none"]
-WIRELESS_SOFTWARES = ["hostapd", "iwinfo"]
+WIRELESS_SOFTWARES = ["hostapd", "iwinfo", "none"]
 
 # Sensor enable/disable configuration
 CONF_ENABLE_QMODEM_SENSORS = "enable_qmodem_sensors"

--- a/custom_components/openwrt_ubus/shared_data_manager.py
+++ b/custom_components/openwrt_ubus/shared_data_manager.py
@@ -289,8 +289,10 @@ class SharedUbusDataManager:
             # Get device statistics and connection info
             if wireless_software == "hostapd":
                 return await self._fetch_hostapd_data(mac2name)
-            else:
+            elif wireless_software == "iwinfo":
                 return await self._fetch_iwinfo_data(mac2name)
+            else:
+                return {}
         except Exception as exc:
             _LOGGER.error("Error fetching device statistics: %s", exc)
             raise UpdateFailed(f"Error fetching device statistics: {exc}")


### PR DESCRIPTION
Add a `none` wireless software option for not tracking WiFi devices at all. This is useful if one in not interested in WiFi devices or tracks them using different integrations (e.g. because of issue https://github.com/FUjr/homeassistant-openwrt-ubus/issues/20).