### PR TITLE
Add /etc/ethers support and SSID-based network naming

### DIFF
--- a/custom_components/openwrt_ubus/const.py
+++ b/custom_components/openwrt_ubus/const.py
@@ -65,6 +65,7 @@ API_SUBSYS_SYSTEM = "system"
 API_SUBSYS_UCI = "uci"
 API_SUBSYS_QMODEM = "modem_ctrl"
 API_SUBSYS_RC = "rc"
+API_SUBSYS_WIRELESS = "network.wireless"
 
 # API methods
 API_METHOD_BOARD = "board"

--- a/custom_components/openwrt_ubus/device_tracker.py
+++ b/custom_components/openwrt_ubus/device_tracker.py
@@ -256,12 +256,27 @@ class OpenwrtDeviceTracker(CoordinatorEntity, ScannerEntity):
         device_data = device_stats.get(self.mac_address) or device_stats.get(self.mac_address.upper())
         
         if device_data:
-            base_name = f"{connected_router}({self.ap_device})" if self.ap_device != "Unknown AP" else connected_router
+            # Use SSID instead of physical interface name
+            ssid = device_data.get("ap_ssid", "Unknown SSID")
+            base_name = f"{connected_router}({ssid})" if ssid != "Unknown SSID" else connected_router
+            
             hostname = device_data.get("hostname")
+            
+            # Show hostname if available and meaningful
             if hostname and hostname != self.mac_address and hostname != self.mac_address.upper() and hostname != "*":
-                return f"{base_name} {hostname}"
+                # If hostname looks like a domain name, use it directly
+                if "." in hostname:
+                    return f"{base_name} {hostname.split('.')[0]}"
+                else:
+                    return f"{base_name} {hostname}"
             else:
-                return f"{base_name} {self.mac_address.replace(':', '')}"
+                # Try to show IP address if hostname not available
+                ip_address = device_data.get("ip_address", "")
+                if ip_address and ip_address != "Unknown IP":
+                    return f"{base_name} {ip_address}"
+                else:
+                    # Fallback to MAC address
+                    return f"{base_name} {self.mac_address.replace(':', '')}"
         
         # Fallback to MAC address if no device data found
         return f"{connected_router} {self.mac_address.replace(':', '')}"


### PR DESCRIPTION
This commit adds two enhancements to device and network identification:

1. **Hostname resolution via /etc/ethers**: Added support for reading /etc/ethers file to map MAC addresses to hostnames. This provides an additional source of device name information beyond DHCP leases, particularly useful for static IP devices or manual MAC-hostname mappings.

2. **SSID-based network interface naming**: Access point interfaces now display their SSID name instead of the physical interface name (e.g., "MyWiFi" instead of "phy0-ap0"), making network identification more intuitive for users.

Implementation details:
- Added get_ethers_mapping() method to read and parse /etc/ethers
- Added get_interface_to_ssid_mapping() via network.wireless.status API
- Integrated both mappings in device tracker for enhanced device identification
- Added caching for interface-to-SSID mapping to reduce API calls