### PR TITLE
feat: improve session handling

### DIFF
--- a/custom_components/openwrt_ubus/Ubus/const.py
+++ b/custom_components/openwrt_ubus/Ubus/const.py
@@ -24,7 +24,9 @@ API_PARAM_USERNAME = "username"
 API_SUBSYS_SESSION = "session"
 
 # Basic methods
-API_METHOD_LOGIN = "login"
+API_SESSION_METHOD_LOGIN = "login"
+API_SESSION_METHOD_DESTROY = "destroy"
+API_SESSION_METHOD_LIST = "list"
 
 # Common ubus error codes
 UBUS_ERROR_SUCCESS = 0
@@ -39,3 +41,14 @@ UBUS_ERROR_NOT_SUPPORTED = 8
 UBUS_ERROR_UNKNOWN_ERROR = 9
 
 HTTP_STATUS_OK = 200
+
+
+def _get_error_message(error_code):
+    """Get descriptive error message for ubus error codes."""
+    error_messages = {
+        UBUS_ERROR_SUCCESS: "Success",
+        UBUS_ERROR_PERMISSION_DENIED: "Permission Denied",
+        UBUS_ERROR_NOT_FOUND: "Not Found",
+        UBUS_ERROR_NO_DATA: "No Data",
+    }
+    return error_messages.get(error_code, f"Unknown Error ({error_code})")

--- a/custom_components/openwrt_ubus/Ubus/interface.py
+++ b/custom_components/openwrt_ubus/Ubus/interface.py
@@ -14,23 +14,41 @@ from .const import (
     API_DEF_VERIFY,
     API_ERROR,
     API_MESSAGE,
-    API_METHOD_LOGIN,
+    API_SESSION_METHOD_LOGIN,
     API_PARAM_PASSWORD,
     API_PARAM_USERNAME,
     API_RESULT,
     API_RPC_CALL,
-    API_RPC_ID,
     API_RPC_VERSION,
     API_SUBSYS_SESSION,
     API_UBUS_RPC_SESSION,
     HTTP_STATUS_OK,
     UBUS_ERROR_SUCCESS,
-    UBUS_ERROR_PERMISSION_DENIED,
-    UBUS_ERROR_NOT_FOUND,
-    UBUS_ERROR_NO_DATA, API_UBUS_RPC_SESSION_EXPIRES,
+    API_UBUS_RPC_SESSION_EXPIRES, _get_error_message, API_SESSION_METHOD_DESTROY, API_SESSION_METHOD_LIST,
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+
+class PreparedCall:
+    def __init__(
+            self,
+            rpc_method: str,
+            subsystem: str | None = None,
+            method: str | None = None,
+            params: dict | None = None,
+            rpc_id: str | None = None,
+    ):
+        self.rpc_method = rpc_method
+        self.subsystem = subsystem
+        self.method = method
+        self.params = params
+        self.id = rpc_id
+
+
+class RPCError(RuntimeError):
+    """Custom exception for RPC errors."""
+    pass
 
 
 class Ubus:
@@ -54,8 +72,7 @@ class Ubus:
         self.verify = verify
 
         self.debug_api = API_DEF_DEBUG
-        self.rpc_id = API_RPC_ID
-        self.session_id = None
+        self.session_id: str | None = None
         self.session_expire = 0
         self._session_created_internally = False
 
@@ -63,8 +80,13 @@ class Ubus:
         """Set the aiohttp session to use."""
         self.session = session
 
-    def logout(self):
+    async def logout(self):
         """Clear the current session ID."""
+        await self._api_call(
+            API_RPC_CALL,
+            API_SUBSYS_SESSION,
+            API_SESSION_METHOD_DESTROY,
+        )
         self.session_id = None
         self.session_expire = 0
 
@@ -79,124 +101,162 @@ class Ubus:
         if self.session_expire <= (time.time() - 15):
             await self.connect()
 
-    def build_api(
-            self,
-            rpc_method: str,
-            subsystem: str = None,
-            method: str = None,
-            params: dict = None,
-    ):
-        """Build API call data."""
-        if self.debug_api:
-            _LOGGER.debug(
-                'api build: rpc_method="%s" subsystem="%s" method="%s" params="%s"',
-                rpc_method,
-                subsystem,
-                method,
-                params,
-            )
-
-        _params: list[Any] = [subsystem]
-        if rpc_method == API_RPC_CALL:
-            if method:
-                _params.append(method)
-
-            if params:
-                _params.append(params)
-            else:
-                _params.append({})
-
-        data = json.dumps(
-            {
-                "jsonrpc": API_RPC_VERSION,
-                "id": self.rpc_id,
-                "method": rpc_method,
-                "params": _params,
-            }
-        )
-        self.rpc_id += 1
-        return data
-
-    async def batch_call(self, rpcs: list[dict]):
-        """Execute multiple API calls in a single batch request."""
-        self._ensure_session()
-        await self._ensure_session_is_valid()
-
-        for rpc in rpcs:
-            rpc["params"] = [self.session_id] + rpc.get("params", [])
-
-        try:
-            response = await self.session.post(
-                self.host, data=json.dumps(rpcs), timeout=self.timeout, verify_ssl=self.verify
-            )
-        except aiohttp.ClientError as req_exc:
-            _LOGGER.error("batch_call exception: %s", req_exc)
-            return None
-
-        if response.status != HTTP_STATUS_OK:
-            return None
-
-        json_response = await response.json()
-
-        if self.debug_api:
-            _LOGGER.debug(
-                'batch call: status="%s" response="%s"',
-                response.status,
-                json_response,
-            )
-
-        # For batch calls, the response is typically an array of responses
-        if isinstance(json_response, list):
-            # Check first result for permission error to handle batch-level permissions
-            if json_response and len(json_response) > 0:
-                first_result = json_response[0]
-                if "error" in first_result:
-                    error_msg = first_result["error"].get("message", "")
-                    if "Access denied" in error_msg:
-                        raise PermissionError(error_msg)
-            return json_response
-
-        # Handle single response format (fallback)
-        if API_ERROR in json_response:
-            error_message = json_response[API_ERROR].get(API_MESSAGE, "Unknown error")
-            error_code = json_response[API_ERROR].get("code", -1)
-
-            # Special handling for permission errors
-            if error_code == -32002 or "Access denied" in error_message:
-                _LOGGER.warning(
-                    "Permission denied when calling %s.%s: %s (code: %d)",
-                    subsystem,
-                    method,
-                    error_message,
-                    error_code
-                )
-                raise PermissionError(
-                    f"Permission denied for {subsystem}.{method}: {error_message} (code: {error_code})"
-                )
-
-            # General error handling
-            _LOGGER.error(
-                "API call failed for %s.%s: %s (code: %d)",
-                subsystem,
-                method,
-                error_message,
-                error_code
-            )
-            raise ConnectionError(
-                f"API call failed for {subsystem}.{method}: {error_message} (code: {error_code})"
-            )
-        return [json_response]
-
     async def api_call(
             self,
             rpc_method: str,
             subsystem: str | None = None,
             method: str | None = None,
             params: dict | None = None,
-    ):
+    ) -> dict | list | None:
         """Perform API call."""
         await self._ensure_session_is_valid()
         return await self._api_call(rpc_method, subsystem, method, params)
+
+    async def batch_call(self, rpcs: list[PreparedCall]) -> list[tuple[str, dict | list | None | Exception]] | None:
+        """Execute multiple API calls in a single batch request."""
+        await self._ensure_session_is_valid()
+        return await self._batch_call(rpcs)
+
+    async def _batch_call(self, rpcs: list[PreparedCall]) -> list[tuple[str, dict | list | None | Exception]] | None:
+        self._ensure_session()
+
+        if rpcs[0] and rpcs[0].subsystem != API_SUBSYS_SESSION:
+            rpcs.append(
+                PreparedCall(  # Session list call for getting the session expiration
+                    rpc_method=API_RPC_CALL,
+                    subsystem=API_SUBSYS_SESSION,
+                    method=API_SESSION_METHOD_LIST,
+                    rpc_id="refresh_expiration",
+                )
+            )
+
+        rpc_calls = []
+        for rpc in rpcs:
+            params: list[Any] = [self.session_id or API_DEF_SESSION_ID, rpc.subsystem]
+            if rpc.rpc_method == API_RPC_CALL:
+                if rpc.method:
+                    params.append(rpc.method)
+
+                if rpc.params:
+                    params.append(rpc.params)
+                else:
+                    params.append({})
+            rpc_call = {
+                "jsonrpc": API_RPC_VERSION,
+                "method": rpc.rpc_method,
+                "params": params,
+            }
+            if rpc.id is not None:
+                rpc_call["id"] = rpc.id
+            rpc_calls.append(rpc_call)
+
+        response = await self.session.post(
+            self.host, data=json.dumps(rpc_calls), timeout=self.timeout, verify_ssl=self.verify
+        )
+
+        if response.status != HTTP_STATUS_OK:
+            return None
+
+        responses = await response.json()
+
+        if self.debug_api:
+            _LOGGER.debug(
+                'batch call: status="%s" response="%s"',
+                response.status,
+                responses,
+            )
+
+        # For batch calls, the response is an array of responses
+        if isinstance(responses, list):
+            results: list[tuple[str, dict | list | None | Exception]] = []
+            for i, response in enumerate(responses):
+                result_id = response.get("id", "")
+
+                def _append_result(_result: dict | list | None | Exception):
+                    results.append((result_id, _result))
+
+                if API_ERROR in response:
+                    subsystem = rpcs[i].subsystem
+                    method = rpcs[i].method
+                    error_message = response[API_ERROR].get(API_MESSAGE, "Unknown error")
+                    error_code = response[API_ERROR].get("code", -1)
+
+                    # Special handling for permission errors
+                    if error_code == -32002 or "Access denied" in error_message:
+                        _LOGGER.warning(
+                            "Permission denied when calling %s.%s: %s (code: %d)",
+                            subsystem,
+                            method,
+                            error_message,
+                            error_code
+                        )
+                        _append_result(
+                            PermissionError(
+                                f"Permission denied for {subsystem}.{method}: {error_message} (code: {error_code})"
+                            )
+                        )
+                    else:
+                        # General error handling
+                        _LOGGER.error(
+                            "API call failed for %s.%s: %s (code: %d)",
+                            subsystem,
+                            method,
+                            error_message,
+                            error_code
+                        )
+                        _append_result(
+                            ConnectionError(
+                                f"API call failed for {subsystem}.{method}: {error_message} (code: {error_code})"
+                            )
+                        )
+                else:
+                    result = response[API_RESULT]
+                    if rpcs[i].rpc_method == API_RPC_CALL:
+                        if isinstance(result, list):
+                            error_code = result[0]
+                            error_msg = _get_error_message(error_code)
+                            if len(result) == 2:
+                                if error_code == UBUS_ERROR_SUCCESS:
+                                    # Success - return the data
+                                    _append_result(result[1])
+                                else:
+                                    # Error code - log with descriptive message and return None
+                                    _append_result(
+                                        RPCError(
+                                            f"API call failed with error code {error_code} ({error_msg}): {result[1]}"
+                                        )
+                                    )
+                            elif len(result) == 1:
+                                if error_code == UBUS_ERROR_SUCCESS:
+                                    # No data returned but success
+                                    _append_result(None)
+                                else:
+                                    _append_result(
+                                        RPCError(
+                                            f"API call failed with error code {error_code} ({error_msg}): No error message"
+                                        )
+                                    )
+                            else:
+                                _append_result(ConnectionError(f"Unexpected API call result format: {result}"))
+                        else:
+                            _append_result(ConnectionError(f"Unexpected API call result format: {result}"))
+                    else:
+                        _append_result(result)
+            if results[-1][0] == "refresh_expiration":
+                session_response = results.pop()[1]
+                if isinstance(session_response, Exception):
+                    try:
+                        raise session_response
+                    except (RPCError, PermissionError) as e:
+                        _LOGGER.warning("Failed to retrieve session expiration: %s", e)
+                elif isinstance(session_response, list):
+                    raise ConnectionError(f"Unexpected session API response format: {session_response}")
+                elif isinstance(session_response, dict):
+                    self.session_expire = time.time() + session_response.get("expires", 0)
+
+            return results
+        else:
+            raise ConnectionError(f"Unexpected API response format: {responses}")
 
     async def _api_call(
             self,
@@ -204,8 +264,7 @@ class Ubus:
             subsystem: str | None = None,
             method: str | None = None,
             params: dict | None = None,
-    ):
-        self._ensure_session()
+    ) -> dict | list | None:
         if self.debug_api:
             _LOGGER.debug(
                 'api call: rpc_method="%s" subsystem="%s" method="%s" params="%s"',
@@ -215,116 +274,22 @@ class Ubus:
                 params,
             )
 
-        _params = [self.session_id, subsystem]
-        if rpc_method == API_RPC_CALL:
-            if method:
-                _params.append(method)
-
-            if params:
-                _params.append(params)
-            else:
-                _params.append({})
-
-        data = json.dumps(
-            {
-                "jsonrpc": API_RPC_VERSION,
-                "id": self.rpc_id,
-                "method": rpc_method,
-                "params": _params,
-            }
-        )
-        if self.debug_api:
-            _LOGGER.debug('api call: data="%s"', data)
-
-        self.rpc_id += 1
-        try:
-            response = await self.session.post(
-                self.host, data=data, timeout=self.timeout, verify_ssl=self.verify
-            )
-        except aiohttp.ClientError as req_exc:
-            _LOGGER.error("api_call exception: %s", req_exc)
+        results = await self._batch_call([
+            PreparedCall(
+                rpc_method=rpc_method,
+                subsystem=subsystem,
+                method=method,
+                params=params,
+            ),
+        ])
+        if results is None:
             return None
 
-        if response.status != HTTP_STATUS_OK:
-            return None
+        _, response = results[0]
+        if isinstance(response, Exception):
+            raise response
 
-        json_response = await response.json()
-
-        if self.debug_api:
-            _LOGGER.debug(
-                'api call: status="%s" response="%s"',
-                response.status,
-                json_response,
-            )
-
-        if API_ERROR in json_response:
-            error_message = json_response[API_ERROR].get(API_MESSAGE, "Unknown error")
-            error_code = json_response[API_ERROR].get("code", -1)
-
-            # Special handling for permission errors
-            if error_code == -32002 or "Access denied" in error_message:
-                _LOGGER.warning(
-                    "Permission denied when calling %s.%s: %s (code: %d)",
-                    subsystem,
-                    method,
-                    error_message,
-                    error_code
-                )
-                raise PermissionError(
-                    f"Permission denied for {subsystem}.{method}: {error_message} (code: {error_code})"
-                )
-
-            # General error handling
-            _LOGGER.error(
-                "API call failed for %s.%s: %s (code: %d)",
-                subsystem,
-                method,
-                error_message,
-                error_code
-            )
-            raise ConnectionError(
-                f"API call failed for {subsystem}.{method}: {error_message} (code: {error_code})"
-            )
-
-        if rpc_method == API_RPC_CALL:
-            try:
-                result = json_response[API_RESULT]
-                if isinstance(result, list) and len(result) > 1:
-                    # Check if first element is an error code
-                    error_code = result[0]
-                    if error_code == UBUS_ERROR_SUCCESS:
-                        # Success - return the data
-                        return result[1]
-                    else:
-                        # Error code - log with descriptive message and return None
-                        error_msg = self._get_error_message(error_code)
-                        _LOGGER.debug("API call failed with error code %s (%s): %s",
-                                      error_code, error_msg, result[1] if len(result) > 1 else "No error message")
-                        return None
-                elif isinstance(result, list) and len(result) == 1:
-                    # Single element result - might be an error code
-                    error_code = result[0]
-                    error_msg = self._get_error_message(error_code)
-                    _LOGGER.debug("API call failed with error code %s (%s) - no error message", error_code, error_msg)
-                    return None
-                else:
-                    _LOGGER.debug("Unexpected result format: %s", result)
-                    return None
-            except (IndexError, KeyError) as exc:
-                _LOGGER.debug("Error parsing API result: %s", exc)
-                return None
-        else:
-            return json_response[API_RESULT]
-
-    def _get_error_message(self, error_code):
-        """Get descriptive error message for ubus error codes."""
-        error_messages = {
-            UBUS_ERROR_SUCCESS: "Success",
-            UBUS_ERROR_PERMISSION_DENIED: "Permission Denied",
-            UBUS_ERROR_NOT_FOUND: "Not Found",
-            UBUS_ERROR_NO_DATA: "No Data",
-        }
-        return error_messages.get(error_code, f"Unknown Error ({error_code})")
+        return response
 
     def api_debugging(self, debug_api):
         """Enable/Disable API calls debugging."""
@@ -338,14 +303,12 @@ class Ubus:
 
     async def connect(self):
         """Connect to OpenWrt ubus API."""
-        self.rpc_id = 1
-        self.session_id = API_DEF_SESSION_ID
         self.session_expire = 0
 
         login = await self._api_call(
             API_RPC_CALL,
             API_SUBSYS_SESSION,
-            API_METHOD_LOGIN,
+            API_SESSION_METHOD_LOGIN,
             {
                 API_PARAM_USERNAME: self.username,
                 API_PARAM_PASSWORD: self.password,

--- a/custom_components/openwrt_ubus/shared_data_manager.py
+++ b/custom_components/openwrt_ubus/shared_data_manager.py
@@ -90,10 +90,10 @@ class SharedUbusDataManager:
         self._ubus_clients: Dict[str, ExtendedUbus] = {}
         self._session = None
 
-    def logout(self):
+    async def logout(self):
         """Logout all ubus clients."""
         for client in self._ubus_clients.values():
-            client.logout()
+            await client.logout()
 
     async def _get_ubus_client(self, client_type: str = "default") -> ExtendedUbus:
         """Get or create ubus client instance."""
@@ -274,7 +274,7 @@ class SharedUbusDataManager:
         try:
             # Get AP devices
             ap_devices_result = await client.get_hostapd()
-            ap_devices = client.parse_hostapd_ap_devices(ap_devices_result) if ap_devices_result else []
+            ap_devices = list(ap_devices_result.keys()) if ap_devices_result else []
 
             device_statistics = {}
 


### PR DESCRIPTION
Apparently the sessions are automatically refreshed on usage.
As we can't be certain about how much they will be extended for,
I added an additional call in batch to every call, that uses
session.list to get the currently left seconds.
Without this, the integration creates new sessions because it thinks the
old session is expired, which it in did not, which can result in "lots" of
open session on the openwrt device.
