### PR TITLE
Improve device deletion logic

### DIFF
--- a/custom_components/openwrt_ubus/sensors/ap_sensor.py
+++ b/custom_components/openwrt_ubus/sensors/ap_sensor.py
@@ -362,6 +362,16 @@ async def async_setup_entry(
     # Perform first refresh
     await coordinator.async_config_entry_first_refresh()
 
+    host = coordinator.data_manager.entry.data[CONF_HOST]
+    device_registry = dr.async_get(hass)
+    device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, f"{host}_ap")},
+        name=f"{host} Access Points",
+        manufacturer="OpenWrt",
+        via_device=(DOMAIN, host),  # Link to main router device
+    )
+
     # Add initial sensors for any devices already discovered
     initial_entities = []
     if coordinator.data and coordinator.data.get("ap_info"):
@@ -431,7 +441,7 @@ class ApSensor(CoordinatorEntity, SensorEntity):
             name=device_name,
             manufacturer="OpenWrt",
             model="Access Point",
-            via_device=(DOMAIN, self._host),
+            via_device=(DOMAIN, f"{self._host}_ap"),
         )
 
     @property

--- a/custom_components/openwrt_ubus/sensors/mwan3_sensor.py
+++ b/custom_components/openwrt_ubus/sensors/mwan3_sensor.py
@@ -16,6 +16,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfTime, CONF_HOST
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers import entity_registry as er
@@ -306,6 +307,16 @@ async def async_setup_entry(
     # Fetch initial data to potentially create initial entities
     await coordinator.async_config_entry_first_refresh()
 
+    host = coordinator.data_manager.entry.data[CONF_HOST]
+    device_registry = dr.async_get(hass)
+    device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, f"{host}_mwan3")},
+        name=f"{host} MWAN3 Interfaces and Policies",
+        manufacturer="OpenWrt",
+        via_device=(DOMAIN, host),  # Link to main router device
+    )
+
     # Create initial entities for existing interfaces and policies
     initial_entities = []
 
@@ -388,7 +399,7 @@ class MWAN3InterfaceSensor(CoordinatorEntity, SensorEntity):
             manufacturer="OpenWrt",
             model="MWAN3 Interface",
             configuration_url=f"http://{self._host}",
-            via_device=(DOMAIN, self._host),
+            via_device=(DOMAIN, f"{self._host}_mwan3"),
         )
 
     @property
@@ -540,7 +551,7 @@ class MWAN3PolicySensor(CoordinatorEntity, SensorEntity):
             manufacturer="OpenWrt",
             model="MWAN3 Policy",
             configuration_url=f"http://{self._host}",
-            via_device=(DOMAIN, self._host),
+            via_device=(DOMAIN, f"{self._host}_mwan3"),
         )
 
     @property


### PR DESCRIPTION
When the STA sensor is enabled only a limited number of interface sensors will not be removed (eth0, br-lan, lan, wan). Instead of continuing to have more and more edge cases based on the name, this creates a new parent device for:
* Interfaces
* Access Points
* MWAN3

Then the deletion logic when these options are disabled is updated to delete children of these new devices and this device. This means the STA deletion logic only needs to exclude these top level "parent" devices.