### PR TITLE
Add consider_home support and fix wired device tracking for uniqueid method

### DIFF
--- a/custom_components/openwrt_ubus/config_flow.py
+++ b/custom_components/openwrt_ubus/config_flow.py
@@ -71,6 +71,8 @@ from .const import (
     DEFAULT_WIRED_TRACKER_NAME_PRIORITY,
     DEFAULT_WIRED_TRACKER_WHITELIST,
     DEFAULT_WIRED_TRACKER_INTERFACES,
+    CONF_CONSIDER_HOME,
+    DEFAULT_CONSIDER_HOME,
     DEFAULT_SYSTEM_SENSOR_TIMEOUT,
     DEFAULT_QMODEM_SENSOR_TIMEOUT,
     DEFAULT_STA_SENSOR_TIMEOUT,
@@ -534,6 +536,10 @@ class OpenwrtUbusOptionsFlow(OptionsFlow):
                     CONF_MWAN3_SENSOR_TIMEOUT,
                     default=current_data.get(CONF_MWAN3_SENSOR_TIMEOUT, DEFAULT_MWAN3_SENSOR_TIMEOUT),
                 ): vol.All(vol.Coerce(int), vol.Range(min=30, max=600)),
+                vol.Optional(
+                    CONF_CONSIDER_HOME,
+                    default=current_data.get(CONF_CONSIDER_HOME, DEFAULT_CONSIDER_HOME),
+                ): vol.All(vol.Coerce(int), vol.Range(min=0, max=1800)),
                 vol.Optional("refresh_services", default=False): bool,
             }
         )

--- a/custom_components/openwrt_ubus/const.py
+++ b/custom_components/openwrt_ubus/const.py
@@ -73,6 +73,10 @@ DEFAULT_WIRED_TRACKER_NAME_PRIORITY = "ipv4"  # Options: ipv4, ipv6, mac
 DEFAULT_WIRED_TRACKER_WHITELIST = []  # Empty list means no filtering
 DEFAULT_WIRED_TRACKER_INTERFACES = []  # Empty list means no interface filtering
 
+# Consider home configuration
+CONF_CONSIDER_HOME = "consider_home"
+DEFAULT_CONSIDER_HOME = 300  # seconds before marking device as not_home
+
 # API constants - moved from Ubus/const.py
 API_RPC_CALL = "call"
 API_RPC_LIST = "list"

--- a/custom_components/openwrt_ubus/device_tracker.py
+++ b/custom_components/openwrt_ubus/device_tracker.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from datetime import timedelta
+from datetime import datetime, timedelta
 from typing import Any
 
 import voluptuous as vol
@@ -29,10 +29,12 @@ from homeassistant.helpers.update_coordinator import (
 )
 
 from .const import (
+    CONF_CONSIDER_HOME,
     CONF_DHCP_SOFTWARE,
     CONF_WIRELESS_SOFTWARE,
     CONF_TRACKING_METHOD,
     CONF_ENABLE_WIRED_TRACKER,
+    DEFAULT_CONSIDER_HOME,
     DEFAULT_DHCP_SOFTWARE,
     DEFAULT_WIRELESS_SOFTWARE,
     DEFAULT_TRACKING_METHOD,
@@ -457,6 +459,11 @@ class OpenwrtDeviceTracker(CoordinatorEntity, ScannerEntity):
         self._attr_unique_id = _generate_unique_id(self._host, mac_address, self._tracking_method)
         self._attr_name = None  # Will be set dynamically
         self._attr_entity_registry_enabled_default = True  # Enable by default
+        self._last_seen: datetime | None = None
+        consider_home_seconds = coordinator.data_manager.entry.data.get(
+            CONF_CONSIDER_HOME, DEFAULT_CONSIDER_HOME
+        )
+        self._consider_home = timedelta(seconds=consider_home_seconds)
 
     def _get_device_data_from_any_coordinator(self) -> tuple[dict | None, str | None]:
         """Get device data from any coordinator (for uniqueid tracking method).
@@ -465,11 +472,19 @@ class OpenwrtDeviceTracker(CoordinatorEntity, ScannerEntity):
             Tuple of (device_data, coordinator_host) or (None, None) if not found
         """
         # First try the local coordinator (most likely case)
+        # Check WiFi devices (device_statistics)
         device_stats = self.coordinator.data.get("device_statistics", {})
         device_data = device_stats.get(self.mac_address) or device_stats.get(self.mac_address.upper())
 
         if device_data and device_data.get("connected"):
             return device_data, self._host
+
+        # Check wired devices
+        wired_devices = self.coordinator.data.get("wired_devices", {})
+        wired_data = wired_devices.get(self.mac_address) or wired_devices.get(self.mac_address.upper())
+
+        if wired_data and wired_data.get("connected"):
+            return wired_data, self._host
 
         # If not found locally and tracking method is uniqueid, search in all coordinators
         if self._tracking_method == "uniqueid":
@@ -485,12 +500,11 @@ class OpenwrtDeviceTracker(CoordinatorEntity, ScannerEntity):
                 if not other_coordinator.data:
                     continue
 
-                # Look for device in this coordinator's data
+                # Look for device in this coordinator's WiFi data
                 other_stats = other_coordinator.data.get("device_statistics", {})
                 device_data = other_stats.get(self.mac_address) or other_stats.get(self.mac_address.upper())
 
                 if device_data and device_data.get("connected"):
-                    # Found on another router
                     other_host = other_coordinator.data_manager.entry.data[CONF_HOST]
                     _LOGGER.debug(
                         "Device %s found on router %s (not on %s)",
@@ -499,6 +513,20 @@ class OpenwrtDeviceTracker(CoordinatorEntity, ScannerEntity):
                         self._host,
                     )
                     return device_data, other_host
+
+                # Look for device in this coordinator's wired data
+                other_wired = other_coordinator.data.get("wired_devices", {})
+                wired_data = other_wired.get(self.mac_address) or other_wired.get(self.mac_address.upper())
+
+                if wired_data and wired_data.get("connected"):
+                    other_host = other_coordinator.data_manager.entry.data[CONF_HOST]
+                    _LOGGER.debug(
+                        "Device %s found in wired devices on router %s (not on %s)",
+                        self.mac_address,
+                        other_host,
+                        self._host,
+                    )
+                    return wired_data, other_host
 
         # Not found anywhere
         return None, None
@@ -635,6 +663,17 @@ class OpenwrtDeviceTracker(CoordinatorEntity, ScannerEntity):
 
         return self._attr_mac_address.replace(":", "")
 
+    def _check_consider_home(self, connected: bool) -> bool:
+        """Apply consider_home logic: keep device home for a grace period."""
+        now = datetime.now()
+        if connected:
+            self._last_seen = now
+            return True
+        # Not currently seen, check if within consider_home window
+        if self._last_seen and (now - self._last_seen) < self._consider_home:
+            return True
+        return False
+
     @property
     def is_connected(self) -> bool:
         """Return true if the device is connected to the network."""
@@ -654,25 +693,25 @@ class OpenwrtDeviceTracker(CoordinatorEntity, ScannerEntity):
                     )
                 else:
                     _LOGGER.debug("Device %s connection status: %s", self.mac_address, connected)
-                return connected
+                return self._check_consider_home(connected)
 
             _LOGGER.debug(
                 "Device %s not found in any device statistics, assuming disconnected",
                 self.mac_address,
             )
-            return False
+            return self._check_consider_home(False)
 
         # For combined tracking, use simplified logic from main
         if device_data := self._device_data():
             connected = device_data.get("connected", False)
             _LOGGER.debug("Device %s connection status: %s", self._attr_mac_address, connected)
-            return connected
+            return self._check_consider_home(connected)
 
         _LOGGER.debug(
             "Device %s not found in device statistics, assuming disconnected",
             self._attr_mac_address,
         )
-        return False
+        return self._check_consider_home(False)
 
     @property
     def extra_state_attributes(self) -> dict[str, str]:

--- a/custom_components/openwrt_ubus/strings.json
+++ b/custom_components/openwrt_ubus/strings.json
@@ -100,7 +100,8 @@
           "qmodem_sensor_timeout": "QModem Sensor Update Interval (seconds)",
           "sta_sensor_timeout": "Station Sensor Update Interval (seconds)",
           "ap_sensor_timeout": "Access Point Sensor Update Interval (seconds)",
-          "tracking_method": "Tracking Method"
+          "tracking_method": "Tracking Method",
+          "consider_home": "Consider Home Delay (seconds)"
         },
         "data_description": {
           "use_https": "Whether to use HTTPS (SSL/TLS) when connecting to the router",
@@ -123,7 +124,8 @@
           "qmodem_sensor_timeout": "How often to update modem sensor data (30-600 seconds)",
           "sta_sensor_timeout": "How often to update station device data (10-300 seconds)",
           "ap_sensor_timeout": "How often to update access point data (30-600 seconds)",
-          "tracking_method": "Tracking method for devices: 'uniqueid' uses MAC address only (device roams between APs), 'combined' uses AP+MAC (separate entities per AP)"
+          "tracking_method": "Tracking method for devices: 'uniqueid' uses MAC address only (device roams between APs), 'combined' uses AP+MAC (separate entities per AP)",
+          "consider_home": "Time in seconds to keep a device as 'home' after it was last seen (0-1800). Set to 0 to disable. Useful for devices that temporarily disconnect during WiFi roaming"
         }
       }
     }


### PR DESCRIPTION
## Summary

- **Fix**: `_get_device_data_from_any_coordinator()` now also checks `wired_devices` data, not just `device_statistics` (WiFi). This fixes wired devices (and WiFi devices on secondary dumb APs) always showing as disconnected with the `uniqueid` tracking method. (Fixes #82)
- **Feature**: Add configurable `consider_home` delay (0-1800 seconds, default 300s) to prevent devices from flapping between home/not_home states. This is especially useful for WiFi devices that temporarily disconnect during AP roaming.

## Changes

### `const.py`
- Added `CONF_CONSIDER_HOME` and `DEFAULT_CONSIDER_HOME` (300 seconds)

### `config_flow.py`
- Added `consider_home` field to the options flow UI (range 0-1800 seconds)

### `strings.json`
- Added label and description for the new `consider_home` option

### `device_tracker.py`
- **Bug fix**: `_get_device_data_from_any_coordinator()` now searches both `device_statistics` AND `wired_devices` in local and remote coordinators
- **Feature**: Added `_check_consider_home()` method that keeps a device as "home" for the configured delay after last detection
- Reads `consider_home` value from integration config (configurable via UI)

## Use Case

Setup with multiple dumb APs in bridge mode:
- WiFi devices connected to secondary APs are not seen by the main router's hostapd
- They only appear in `wired_devices` (via IP neighbor table)
- Without the wired_devices fix, these devices could never be tracked as "home"
- Without consider_home, devices briefly show as "not_home" during AP roaming

## Test plan
- [ ] Verify wired devices show correct home/not_home status with `uniqueid` tracking
- [ ] Verify WiFi devices on secondary dumb APs are tracked correctly
- [ ] Verify `consider_home` delay works (device stays home for configured duration)
- [ ] Verify `consider_home: 0` disables the delay (immediate state change)
- [ ] Verify the new option appears in the integration configuration UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)