### PR TITLE
feat: add Connected Clients count per AP and fix service switch state

### DIFF
--- a/custom_components/openwrt_ubus/buttons/service_button.py
+++ b/custom_components/openwrt_ubus/buttons/service_button.py
@@ -102,4 +102,3 @@ class OpenwrtServiceRestartButton(ButtonEntity):
 
         except Exception as exc:
             _LOGGER.error("Failed to restart service %s: %s", self.service_name, exc)
-            raise

--- a/custom_components/openwrt_ubus/extended_ubus.py
+++ b/custom_components/openwrt_ubus/extended_ubus.py
@@ -621,6 +621,9 @@ class ExtendedUbus(Ubus):
 
         _LOGGER.debug("Got service list: %s", service_list_result)
 
+        # Also get procd service list to augment running status
+        procd_services = await self.api_call(API_RPC_CALL, "service", API_METHOD_LIST) or {}
+
         # Build batch calls for each service status
         services_with_status = {}
         prepared_calls: list[PreparedCall] = []
@@ -655,7 +658,7 @@ class ExtendedUbus(Ubus):
                             )
 
                             # Parse service status - OpenWrt RC returns different formats
-                            parsed_status = self._parse_service_status(service_status, service_name)
+                            parsed_status = self._parse_service_status(service_status, service_name, procd_services)
                             services_with_status[service_name] = parsed_status
                         else:
                             _LOGGER.debug(
@@ -692,8 +695,8 @@ class ExtendedUbus(Ubus):
         _LOGGER.debug("Final services with status: %s", services_with_status)
         return services_with_status
 
-    def _parse_service_status(self, status_data, service_name):
-        """Parse service status from RC API response."""
+    def _parse_service_status(self, status_data, service_name, procd_services=None):
+        """Parse service status from RC API response and augment with procd status."""
         _LOGGER.debug(
             "Parsing service status for %s: %s (type: %s)",
             service_name,
@@ -718,6 +721,23 @@ class ExtendedUbus(Ubus):
             running = status_data.get("running", False)
             enabled = status_data.get("enabled", False)
             start_priority = status_data.get("start", 0)
+
+            # Augment with procd data if it's considered not running by RC
+            if procd_services and not running:
+                if service_name in procd_services:
+                    service_procd = procd_services[service_name]
+                    
+                    if "instances" in service_procd:
+                        # Standard service with daemon processes
+                        instances = service_procd["instances"]
+                        for inst in instances.values():
+                            if inst.get("running"):
+                                running = True
+                                break
+                    else:
+                        # Non-daemon service registered as active in procd 
+                        # (e.g., adblock-fast with custom 'data', or qosmate with empty dict)
+                        running = True
 
             _LOGGER.debug(
                 "Service %s: running=%s, enabled=%s, start=%s",

--- a/custom_components/openwrt_ubus/sensors/ap_sensor.py
+++ b/custom_components/openwrt_ubus/sensors/ap_sensor.py
@@ -255,6 +255,14 @@ SENSOR_DESCRIPTIONS = [
         icon="mdi:flag",
         entity_category=None,
     ),
+    SensorEntityDescription(
+        key="clients",
+        name="Connected Clients",
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement="clients",
+        icon="mdi:account-network",
+        entity_category=None,
+    ),
 ]
 
 
@@ -280,7 +288,7 @@ async def async_setup_entry(
     coordinator = SharedDataUpdateCoordinator(
         hass,
         data_manager,
-        ["ap_info"],  # Data types this coordinator needs
+        ["ap_info", "device_statistics"],  # Data types this coordinator needs
         f"{DOMAIN}_ap_{entry.data[CONF_HOST]}",
         scan_interval,
     )
@@ -323,10 +331,14 @@ async def async_setup_entry(
                         continue
 
                     # Check if sensor has required data
-                    ap_data = ap_info_data.get(ap_device, {})
-                    mapping = SENSOR_VALUE_MAPPING.get(description.key)
-                    if mapping and _has_required_data(ap_data, mapping.data_keys):
+                    if description.key == "clients":
+                        # clients sensor doesn't need data from ap_info
                         device_sensors_to_add.append(description)
+                    else:
+                        ap_data = ap_info_data.get(ap_device, {})
+                        mapping = SENSOR_VALUE_MAPPING.get(description.key)
+                        if mapping and _has_required_data(ap_data, mapping.data_keys):
+                            device_sensors_to_add.append(description)
 
                 # Only add sensors that don't already exist and have data
                 if device_sensors_to_add:
@@ -382,9 +394,12 @@ async def async_setup_entry(
 
             # Only add sensors that have the required data
             for description in SENSOR_DESCRIPTIONS:
-                mapping = SENSOR_VALUE_MAPPING.get(description.key)
-                if mapping and _has_required_data(ap_data, mapping.data_keys):
+                if description.key == "clients":
                     initial_entities.append(ApSensor(coordinator, description, ap_device))
+                else:
+                    mapping = SENSOR_VALUE_MAPPING.get(description.key)
+                    if mapping and _has_required_data(ap_data, mapping.data_keys):
+                        initial_entities.append(ApSensor(coordinator, description, ap_device))
 
     # Add initial entities if any
     if initial_entities:
@@ -447,6 +462,13 @@ class ApSensor(CoordinatorEntity, SensorEntity):
     @property
     def available(self) -> bool:
         """Return True if entity is available."""
+        if self.entity_description.key == "clients":
+            return (
+                self.coordinator.last_update_success
+                and self.coordinator.data is not None
+                and "device_statistics" in self.coordinator.data
+            )
+
         if not (
             self.coordinator.last_update_success
             and self.coordinator.data is not None
@@ -467,7 +489,24 @@ class ApSensor(CoordinatorEntity, SensorEntity):
     @property
     def native_value(self) -> str | int | float | None:
         """Return the state of the sensor."""
-        if not self.coordinator.data or "ap_info" not in self.coordinator.data:
+        if not self.coordinator.data:
+            return None
+
+        if self.entity_description.key == "clients":
+            if "device_statistics" not in self.coordinator.data:
+                return 0
+            count = 0
+            dev_stats = self.coordinator.data["device_statistics"]
+            for mac, info in dev_stats.items():
+                ap_dev = info.get("ap_device", "")
+                if ap_dev.startswith("hostapd."):
+                    ap_dev = ap_dev.replace("hostapd.", "", 1)
+                
+                if ap_dev == self.ap_device:
+                    count += 1
+            return count
+
+        if "ap_info" not in self.coordinator.data:
             return None
 
         ap_info_data = self.coordinator.data["ap_info"]

--- a/custom_components/openwrt_ubus/switch.py
+++ b/custom_components/openwrt_ubus/switch.py
@@ -9,7 +9,7 @@ from typing import Any
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import (
@@ -17,6 +17,7 @@ from homeassistant.helpers.update_coordinator import (
     DataUpdateCoordinator,
     UpdateFailed,
 )
+import asyncio
 
 from .const import (
     CONF_SELECTED_SERVICES,
@@ -98,6 +99,13 @@ class OpenwrtServiceSwitch(CoordinatorEntity, SwitchEntity):
         self._attr_unique_id = f"{self._host}_service_{service_name}"
         self._attr_name = f"{service_name}"
         self._attr_entity_registry_enabled_default = True
+        self._optimistic_state: bool | None = None
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        self._optimistic_state = None
+        super()._handle_coordinator_update()
 
     @property
     def device_info(self) -> DeviceInfo:
@@ -112,6 +120,9 @@ class OpenwrtServiceSwitch(CoordinatorEntity, SwitchEntity):
     @property
     def is_on(self) -> bool:
         """Return true if the service is running."""
+        if self._optimistic_state is not None:
+            return self._optimistic_state
+
         if not self.coordinator.data or "service_status" not in self.coordinator.data:
             _LOGGER.debug(
                 "Service %s: No coordinator data or service_status missing. Data keys: %s",
@@ -171,33 +182,49 @@ class OpenwrtServiceSwitch(CoordinatorEntity, SwitchEntity):
         try:
             ubus = await self.coordinator.data_manager.get_ubus_connection_async()
 
+            self._optimistic_state = True
+            self.async_write_ha_state()
+
             # Start the service
             await ubus.service_action(self.service_name, "start")
 
             _LOGGER.info("Started service: %s", self.service_name)
 
-            # Invalidate service status cache and trigger coordinator update
+            # Invalidate service status cache
             self.coordinator.data_manager.invalidate_cache("service_status")
-            await self.coordinator.async_request_refresh()
+            
+            async def delayed_refresh():
+                await asyncio.sleep(2)
+                await self.coordinator.async_request_refresh()
+            self.hass.async_create_task(delayed_refresh())
 
         except Exception as exc:
+            self._optimistic_state = None
+            self.async_write_ha_state()
             _LOGGER.error("Failed to start service %s: %s", self.service_name, exc)
-            raise
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the service off."""
         try:
             ubus = await self.coordinator.data_manager.get_ubus_connection_async()
 
+            self._optimistic_state = False
+            self.async_write_ha_state()
+
             # Stop the service
             await ubus.service_action(self.service_name, "stop")
 
             _LOGGER.info("Stopped service: %s", self.service_name)
 
-            # Invalidate service status cache and trigger coordinator update
+            # Invalidate service status cache
             self.coordinator.data_manager.invalidate_cache("service_status")
-            await self.coordinator.async_request_refresh()
+            
+            async def delayed_refresh():
+                await asyncio.sleep(2)
+                await self.coordinator.async_request_refresh()
+            self.hass.async_create_task(delayed_refresh())
 
         except Exception as exc:
+            self._optimistic_state = None
+            self.async_write_ha_state()
             _LOGGER.error("Failed to stop service %s: %s", self.service_name, exc)
-            raise


### PR DESCRIPTION
- ap_sensor.py: add 'clients' sensor to each AP showing number of connected WiFi stations, sourced from device_statistics (shared with STA coordinator)
- switch.py: add optimistic state for instant UI feedback on toggle, delayed refresh (2s) to allow slow services (adblock, adblock-fast, etc...) to start/stop before polling, remove bare raise on error so HA doesn't mark entity failed
- service_button.py: remove bare raise on error for consistency