### PR TITLE
feat: add wireless device tracker with toggle and whitelist filter

### DIFF
--- a/custom_components/openwrt_ubus/config_flow.py
+++ b/custom_components/openwrt_ubus/config_flow.py
@@ -45,6 +45,8 @@ from .const import (
     CONF_WIRED_TRACKER_NAME_PRIORITY,
     CONF_WIRED_TRACKER_WHITELIST,
     CONF_WIRED_TRACKER_INTERFACES,
+    CONF_ENABLE_WIRELESS_TRACKERS,
+    CONF_WIRELESS_TRACKER_WHITELIST,
     CONF_SELECTED_SERVICES,
     CONF_SYSTEM_SENSOR_TIMEOUT,
     CONF_QMODEM_SENSOR_TIMEOUT,
@@ -71,6 +73,7 @@ from .const import (
     DEFAULT_WIRED_TRACKER_NAME_PRIORITY,
     DEFAULT_WIRED_TRACKER_WHITELIST,
     DEFAULT_WIRED_TRACKER_INTERFACES,
+    DEFAULT_ENABLE_WIRELESS_TRACKERS,
     CONF_CONSIDER_HOME,
     DEFAULT_CONSIDER_HOME,
     DEFAULT_SYSTEM_SENSOR_TIMEOUT,
@@ -119,6 +122,7 @@ STEP_SENSORS_DATA_SCHEMA = vol.Schema(
         vol.Optional(CONF_ENABLE_MWAN3_SENSORS, default=DEFAULT_ENABLE_MWAN3_SENSORS): bool,
         vol.Optional(CONF_ENABLE_SERVICE_CONTROLS, default=DEFAULT_ENABLE_SERVICE_CONTROLS): bool,
         vol.Optional(CONF_ENABLE_DEVICE_KICK_BUTTONS, default=DEFAULT_ENABLE_DEVICE_KICK_BUTTONS): bool,
+        vol.Optional(CONF_ENABLE_WIRELESS_TRACKERS, default=DEFAULT_ENABLE_WIRELESS_TRACKERS): bool,
         vol.Optional(CONF_ENABLE_WIRED_TRACKER, default=DEFAULT_ENABLE_WIRED_TRACKER): bool,
     }
 )
@@ -262,6 +266,10 @@ class OpenwrtUbusConfigFlow(ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             self._sensor_data = user_input
 
+            # If wireless tracker is enabled, proceed to wireless tracker configuration
+            if user_input.get(CONF_ENABLE_WIRELESS_TRACKERS, False):
+                return await self.async_step_wireless_tracker_config()
+
             # If wired tracker is enabled, proceed to wired tracker configuration
             if user_input.get(CONF_ENABLE_WIRED_TRACKER, False):
                 return await self.async_step_wired_tracker_config()
@@ -311,6 +319,46 @@ class OpenwrtUbusConfigFlow(ConfigFlow, domain=DOMAIN):
         return self.async_show_form(
             step_id="wired_tracker_config",
             data_schema=wired_tracker_schema,
+            description_placeholders={"host": self._connection_data[CONF_HOST]},
+        )
+
+    async def async_step_wireless_tracker_config(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
+        """Handle the wireless tracker configuration step."""
+        if user_input is not None:
+            # Merge wireless tracker config into sensor data
+            self._sensor_data.update(user_input)
+
+            # Process whitelist from comma-separated string
+            if CONF_WIRELESS_TRACKER_WHITELIST in self._sensor_data:
+                whitelist_str = self._sensor_data[CONF_WIRELESS_TRACKER_WHITELIST]
+                if isinstance(whitelist_str, str):
+                    self._sensor_data[CONF_WIRELESS_TRACKER_WHITELIST] = [
+                        item.strip() for item in whitelist_str.split(",") if item.strip()
+                    ]
+
+            # If wired tracker is enabled, proceed to wired tracker configuration
+            if self._sensor_data.get(CONF_ENABLE_WIRED_TRACKER, False):
+                return await self.async_step_wired_tracker_config()
+
+            # If service controls are enabled, proceed to services selection
+            if self._sensor_data.get(CONF_ENABLE_SERVICE_CONTROLS, False):
+                return await self.async_step_services()
+
+            return await self.async_step_timeouts()
+
+        # Create schema for wireless tracker configuration
+        wireless_tracker_schema = vol.Schema(
+            {
+                vol.Optional(
+                    CONF_WIRELESS_TRACKER_WHITELIST,
+                    default="",
+                ): cv.string,
+            }
+        )
+
+        return self.async_show_form(
+            step_id="wireless_tracker_config",
+            data_schema=wireless_tracker_schema,
             description_placeholders={"host": self._connection_data[CONF_HOST]},
         )
 
@@ -405,7 +453,17 @@ class OpenwrtUbusOptionsFlow(OptionsFlow):
             if user_input.get("refresh_services", False):
                 return await self.async_step_services()
 
-            # Process whitelist string into list
+            # Process wireless tracker whitelist string into list
+            if CONF_WIRELESS_TRACKER_WHITELIST in user_input:
+                whitelist_str = user_input.get(CONF_WIRELESS_TRACKER_WHITELIST, "")
+                if whitelist_str:
+                    user_input[CONF_WIRELESS_TRACKER_WHITELIST] = [
+                        prefix.strip() for prefix in whitelist_str.split(",") if prefix.strip()
+                    ]
+                else:
+                    user_input[CONF_WIRELESS_TRACKER_WHITELIST] = []
+
+            # Process wired tracker whitelist string into list
             if CONF_WIRED_TRACKER_WHITELIST in user_input:
                 whitelist_str = user_input.get(CONF_WIRED_TRACKER_WHITELIST, "")
                 if whitelist_str:
@@ -500,10 +558,19 @@ class OpenwrtUbusOptionsFlow(OptionsFlow):
                         DEFAULT_ENABLE_DEVICE_KICK_BUTTONS,
                     ),
                 ): bool,
-                vol.Optional(
-                    CONF_ENABLE_WIRED_TRACKER,
-                    default=current_data.get(CONF_ENABLE_WIRED_TRACKER, DEFAULT_ENABLE_WIRED_TRACKER),
-                ): bool,
+                 vol.Optional(
+                     CONF_ENABLE_WIRELESS_TRACKERS,
+                     default=current_data.get(CONF_ENABLE_WIRELESS_TRACKERS, DEFAULT_ENABLE_WIRELESS_TRACKERS),
+                 ): bool,
+                 vol.Optional(
+                     CONF_WIRELESS_TRACKER_WHITELIST,
+                     description={"suggested_value": ",".join(current_data.get(CONF_WIRELESS_TRACKER_WHITELIST, []))},
+                 ): str,
+                 vol.Optional(
+                     CONF_ENABLE_WIRED_TRACKER,
+                     default=current_data.get(CONF_ENABLE_WIRED_TRACKER, DEFAULT_ENABLE_WIRED_TRACKER),
+                 ): bool,
+
                 vol.Optional(
                     CONF_WIRED_TRACKER_NAME_PRIORITY,
                     default=current_data.get(CONF_WIRED_TRACKER_NAME_PRIORITY, DEFAULT_WIRED_TRACKER_NAME_PRIORITY),

--- a/custom_components/openwrt_ubus/const.py
+++ b/custom_components/openwrt_ubus/const.py
@@ -36,6 +36,9 @@ CONF_ENABLE_WIRED_TRACKER = "enable_wired_tracker"
 CONF_WIRED_TRACKER_NAME_PRIORITY = "wired_tracker_name_priority"
 CONF_WIRED_TRACKER_WHITELIST = "wired_tracker_whitelist"
 CONF_WIRED_TRACKER_INTERFACES = "wired_tracker_interfaces"
+# Wireless device tracker configuration
+CONF_ENABLE_WIRELESS_TRACKERS = "enable_wireless_trackers"
+CONF_WIRELESS_TRACKER_WHITELIST = "wireless_tracker_whitelist"
 
 # Timeout configuration
 CONF_SYSTEM_SENSOR_TIMEOUT = "system_sensor_timeout"
@@ -74,6 +77,7 @@ DEFAULT_ENABLE_WIRED_TRACKER = False
 DEFAULT_WIRED_TRACKER_NAME_PRIORITY = "ipv4"  # Options: ipv4, ipv6, mac
 DEFAULT_WIRED_TRACKER_WHITELIST = []  # Empty list means no filtering
 DEFAULT_WIRED_TRACKER_INTERFACES = []  # Empty list means no interface filtering
+DEFAULT_ENABLE_WIRELESS_TRACKERS = False
 
 # Consider home configuration
 CONF_CONSIDER_HOME = "consider_home"

--- a/custom_components/openwrt_ubus/device_tracker.py
+++ b/custom_components/openwrt_ubus/device_tracker.py
@@ -39,6 +39,9 @@ from .const import (
     DEFAULT_WIRELESS_SOFTWARE,
     DEFAULT_TRACKING_METHOD,
     DEFAULT_ENABLE_WIRED_TRACKER,
+    CONF_ENABLE_WIRELESS_TRACKERS,
+    CONF_WIRELESS_TRACKER_WHITELIST,
+    DEFAULT_ENABLE_WIRELESS_TRACKERS,
     DHCP_SOFTWARES,
     DOMAIN,
     WIRELESS_SOFTWARES,
@@ -205,6 +208,16 @@ async def async_setup_entry(
         entry.data.get(CONF_ENABLE_WIRED_TRACKER, DEFAULT_ENABLE_WIRED_TRACKER),
     )
 
+    # Check if wireless tracker is enabled
+    enable_wireless_trackers = entry.options.get(
+        CONF_ENABLE_WIRELESS_TRACKERS,
+        entry.data.get(CONF_ENABLE_WIRELESS_TRACKERS, DEFAULT_ENABLE_WIRELESS_TRACKERS),
+    )
+    wireless_whitelist = entry.options.get(
+        CONF_WIRELESS_TRACKER_WHITELIST,
+        entry.data.get(CONF_WIRELESS_TRACKER_WHITELIST, []),
+    )
+
     # Determine which data types the coordinator needs
     data_types = ["device_statistics"]  # WiFi devices
     if enable_wired_tracker:
@@ -250,9 +263,20 @@ async def async_setup_entry(
         all_devices = {}
         
         # Add WiFi devices
-        if "device_statistics" in coordinator.data:
+        if enable_wireless_trackers and "device_statistics" in coordinator.data:
             device_stats = coordinator.data["device_statistics"]
-            all_devices.update(device_stats)
+            if wireless_whitelist:
+                for mac, device_info in device_stats.items():
+                    ip_address = device_info.get("ip", "")
+                    mac_upper = mac.upper()
+                    if any(
+                        mac_upper.startswith(prefix.upper()) or 
+                        (ip_address and ip_address.startswith(prefix))
+                        for prefix in wireless_whitelist
+                    ):
+                        all_devices[mac] = device_info
+            else:
+                all_devices.update(device_stats)
         
         # Add wired devices
         if enable_wired_tracker and "wired_devices" in coordinator.data:
@@ -289,9 +313,20 @@ async def async_setup_entry(
         all_devices = {}
         
         # Add WiFi devices
-        if "device_statistics" in coordinator.data:
+        if enable_wireless_trackers and "device_statistics" in coordinator.data:
             device_stats = coordinator.data["device_statistics"]
-            all_devices.update(device_stats)
+            if wireless_whitelist:
+                for mac, device_info in device_stats.items():
+                    ip_address = device_info.get("ip", "")
+                    mac_upper = mac.upper()
+                    if any(
+                        mac_upper.startswith(prefix.upper()) or 
+                        (ip_address and ip_address.startswith(prefix))
+                        for prefix in wireless_whitelist
+                    ):
+                        all_devices[mac] = device_info
+            else:
+                all_devices.update(device_stats)
         
         # Add wired devices
         if enable_wired_tracker and "wired_devices" in coordinator.data:

--- a/custom_components/openwrt_ubus/strings.json
+++ b/custom_components/openwrt_ubus/strings.json
@@ -29,7 +29,15 @@
           "enable_eth_sensors": "Enable Network Interface Sensors",
           "enable_service_controls": "Enable Service Controls",
           "enable_device_kick_buttons": "Enable Device Kick Buttons (requires hostapd)",
+          "enable_wireless_trackers": "Enable Wireless Device Tracking",
           "enable_wired_tracker": "Enable Wired Device Tracking"
+        }
+      },
+      "wireless_tracker_config": {
+        "title": "OpenWrt ubus - Wireless Device Tracker Configuration",
+        "description": "Configure wireless device tracking filters for {host}. Leave the whitelist empty to track all connected WiFi devices.",
+        "data": {
+          "wireless_tracker_whitelist": "Whitelist (comma-separated IP/MAC prefixes)"
         }
       },
       "wired_tracker_config": {
@@ -90,6 +98,8 @@
           "enable_eth_sensors": "Enable Network Interface Sensors",
           "enable_service_controls": "Enable Service Controls",
           "enable_device_kick_buttons": "Enable Device Kick Buttons",
+          "enable_wireless_trackers": "Enable Wireless Device Tracking",
+          "wireless_tracker_whitelist": "Wireless Device Whitelist",
           "enable_wired_tracker": "Enable Wired Device Tracking",
           "wired_tracker_name_priority": "Wired Device Name Priority",
           "wired_tracker_whitelist": "Wired Device Whitelist",

--- a/custom_components/openwrt_ubus/translations/en.json
+++ b/custom_components/openwrt_ubus/translations/en.json
@@ -30,7 +30,15 @@
           "enable_mwan3_sensors": "Enable mwan3 Sensors (if mwan3 is installed)",
           "enable_service_controls": "Enable Service Controls",
           "enable_device_kick_buttons": "Enable Device Kick Buttons (requires hostapd)",
+          "enable_wireless_trackers": "Enable Wireless Device Tracking",
           "enable_wired_tracker": "Enable Wired Device Tracking"
+        }
+      },
+      "wireless_tracker_config": {
+        "title": "OpenWrt ubus - Wireless Device Tracker Configuration",
+        "description": "Configure wireless device tracking filters for {host}. Leave the whitelist empty to track all connected WiFi devices.",
+        "data": {
+          "wireless_tracker_whitelist": "Whitelist (comma-separated IP/MAC prefixes)"
         }
       },
       "services": {
@@ -84,6 +92,8 @@
           "enable_mwan3_sensors": "Enable mwan3 Sensors (if mwan3 is installed)",
           "enable_service_controls": "Enable Service Controls",
           "enable_device_kick_buttons": "Enable Device Kick Buttons",
+          "enable_wireless_trackers": "Enable Wireless Device Tracking",
+          "wireless_tracker_whitelist": "Wireless Device Whitelist",
           "enable_wired_tracker": "Enable Wired Device Tracking",
           "wired_tracker_name_priority": "Wired Device Name Priority",
           "wired_tracker_whitelist": "Wired Device Whitelist",


### PR DESCRIPTION
Adds the ability to track WiFi clients as Home Assistant device_tracker entities, parallel to the existing wired device tracker.

- device_tracker.py: gate WiFi devices behind CONF_ENABLE_WIRELESS_TRACKERS; apply optional whitelist filtering by MAC prefix or IP prefix
- const.py: add CONF_ENABLE_WIRELESS_TRACKERS, CONF_WIRELESS_TRACKER_WHITELIST, DEFAULT_ENABLE_WIRELESS_TRACKERS
- config_flow.py: add 'Enable Wireless Device Tracking' to sensors step; add async_step_wireless_tracker_config sub-step for whitelist input; update navigation chain (sensors → wireless → wired → services → timeouts); add wireless fields to options flow init schema with string→list conversion
- strings.json, translations/en.json: add wireless_tracker_config step translations and options flow labels