### PR TITLE
feat: add STA sensor device selection dialog

### DIFF
--- a/custom_components/openwrt_ubus/config_flow.py
+++ b/custom_components/openwrt_ubus/config_flow.py
@@ -27,6 +27,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from . import API_DEF_TIMEOUT
 from .Ubus import Ubus
 from .Ubus.const import API_RPC_CALL
+from .extended_ubus import ExtendedUbus
 from .const import (
     CONF_DHCP_SOFTWARE,
     CONF_WIRELESS_SOFTWARE,
@@ -47,6 +48,8 @@ from .const import (
     CONF_WIRED_TRACKER_INTERFACES,
     CONF_ENABLE_WIRELESS_TRACKERS,
     CONF_WIRELESS_TRACKER_WHITELIST,
+    CONF_SELECT_ALL_STA,
+    CONF_SELECTED_STA,
     CONF_SELECTED_SERVICES,
     CONF_SYSTEM_SENSOR_TIMEOUT,
     CONF_QMODEM_SENSOR_TIMEOUT,
@@ -74,6 +77,8 @@ from .const import (
     DEFAULT_WIRED_TRACKER_WHITELIST,
     DEFAULT_WIRED_TRACKER_INTERFACES,
     DEFAULT_ENABLE_WIRELESS_TRACKERS,
+    DEFAULT_SELECT_ALL_STA,
+    DEFAULT_SELECTED_STA,
     CONF_CONSIDER_HOME,
     DEFAULT_CONSIDER_HOME,
     DEFAULT_SYSTEM_SENSOR_TIMEOUT,
@@ -176,7 +181,7 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
     return {"title": f"OpenWrt ubus {data[CONF_HOST]}"}
 
 
-def create_ubus_from_config(hass: HomeAssistant, data: dict) -> Ubus:
+def create_ubus_from_config(hass: HomeAssistant, data: dict) -> ExtendedUbus:
     session = async_get_clientsession(hass, verify_ssl=data.get(CONF_VERIFY_SSL, False))
     hostname = data[CONF_HOST]
     ip = data.get(CONF_IP_ADDRESS, None)
@@ -184,7 +189,7 @@ def create_ubus_from_config(hass: HomeAssistant, data: dict) -> Ubus:
     port = data.get(CONF_PORT)
     endpoint = data.get(CONF_ENDPOINT, DEFAULT_ENDPOINT)
     url = build_ubus_url(hostname, use_https, ip, port, endpoint)
-    return Ubus(
+    return ExtendedUbus(
         url,
         hostname,
         data[CONF_USERNAME],
@@ -219,6 +224,96 @@ async def get_services_list(hass: HomeAssistant, data: dict[str, Any]) -> list[s
     return []
 
 
+async def get_connected_wifi_devices(hass: HomeAssistant, data: dict[str, Any]) -> dict[str, str]:
+    """Get list of connected WiFi devices from OpenWrt with hostname resolution."""
+    ubus = create_ubus_from_config(hass, data)
+    try:
+        session_id = await ubus.connect()
+        if session_id is None:
+            return {}
+
+        is_hostapd = data.get(CONF_WIRELESS_SOFTWARE, DEFAULT_WIRELESS_SOFTWARE) == "hostapd"
+
+        ap_devices_result = await ubus.get_ap_devices()
+        if not ap_devices_result:
+            return {}
+
+        ap_devices = ubus.parse_ap_devices(ap_devices_result)
+        if not ap_devices:
+            return {}
+
+        # sta_data is {ap_name: {"devices": [mac_list], "statistics": {mac: data}}}
+        sta_data = await ubus.get_all_sta_data_batch(ap_devices, is_hostapd=is_hostapd)
+
+        # Collect all MAC addresses from all APs
+        all_macs = set()
+        if sta_data:
+            for ap_name, ap_sta_info in sta_data.items():
+                if isinstance(ap_sta_info, dict):
+                    for mac in ap_sta_info.get("devices", []):
+                        all_macs.add(str(mac).upper())
+
+        if not all_macs:
+            return {}
+
+        # Try to map MAC addresses to hostnames
+        mac2name: dict[str, str] = {}
+        try:
+            # /etc/ethers has the highest priority
+            ethers_mapping = await ubus.get_ethers_mapping()
+            if ethers_mapping and isinstance(ethers_mapping, dict):
+                for mac, info in ethers_mapping.items():
+                    if isinstance(info, dict):
+                        mac2name[str(mac).upper()] = str(info.get("hostname", ""))
+
+            # DHCP leases as secondary source
+            dhcp_software = data.get(CONF_DHCP_SOFTWARE, DEFAULT_DHCP_SOFTWARE)
+            if dhcp_software == "dnsmasq":
+                result = await ubus.get_uci_config("dhcp", "dnsmasq")
+                leasefile = "/tmp/dhcp.leases"
+                if result and "values" in result:
+                    values = result["values"].values()
+                    leasefile = next(iter(values), {}).get("leasefile", "/tmp/dhcp.leases")
+                lease_result = await ubus.file_read(leasefile)
+                if lease_result and "data" in lease_result:
+                    for line in lease_result["data"].splitlines():
+                        hosts = line.split(" ")
+                        if len(hosts) >= 4:
+                            mac_upper = hosts[1].upper()
+                            if mac_upper not in mac2name:
+                                mac2name[mac_upper] = hosts[3]
+            elif dhcp_software == "odhcpd":
+                result = await ubus.get_dhcp_method("ipv4leases")
+                if result and "device" in result:
+                    for device in result["device"].values():
+                        for lease in device.get("leases", []):
+                            mac = lease.get("mac", "")
+                            if mac and len(mac) == 12:
+                                mac = ":".join(mac[i: i + 2] for i in range(0, len(mac), 2))
+                                mac_upper = mac.upper()
+                                if mac_upper not in mac2name:
+                                    mac2name[mac_upper] = lease.get("hostname", "")
+        except Exception as exc:
+            _LOGGER.debug("Failed to get hostname mappings (non-fatal): %s", exc)
+
+        # Build display strings: "Hostname (MAC)" or just "MAC"
+        devices: dict[str, str] = {}
+        for mac_upper in all_macs:
+            hostname = mac2name.get(mac_upper, "")
+            if hostname and hostname != "*":
+                devices[mac_upper] = f"{hostname} ({mac_upper})"
+            else:
+                devices[mac_upper] = mac_upper
+
+        return devices
+
+    except Exception as exc:
+        _LOGGER.exception("Failed to get connected wifi devices: %s", exc)
+        return {}
+    finally:
+        await ubus.close()
+
+
 class OpenwrtUbusConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for openwrt ubus."""
 
@@ -230,6 +325,7 @@ class OpenwrtUbusConfigFlow(ConfigFlow, domain=DOMAIN):
         self._sensor_data: dict[str, Any] = {}
         self._services_data: dict[str, Any] = {}
         self._available_services: list[str] = []
+        self._available_sta_devices: dict[str, str] = {}
 
     @staticmethod
     @callback
@@ -266,6 +362,10 @@ class OpenwrtUbusConfigFlow(ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             self._sensor_data = user_input
 
+            # If sta sensors enabled, proceed to selection config
+            if user_input.get(CONF_ENABLE_STA_SENSORS, DEFAULT_ENABLE_STA_SENSORS):
+                return await self.async_step_sta_sensors_config()
+
             # If wireless tracker is enabled, proceed to wireless tracker configuration
             if user_input.get(CONF_ENABLE_WIRELESS_TRACKERS, False):
                 return await self.async_step_wireless_tracker_config()
@@ -283,6 +383,44 @@ class OpenwrtUbusConfigFlow(ConfigFlow, domain=DOMAIN):
         return self.async_show_form(
             step_id="sensors",
             data_schema=STEP_SENSORS_DATA_SCHEMA,
+            description_placeholders={"host": self._connection_data[CONF_HOST]},
+        )
+
+    async def async_step_sta_sensors_config(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
+        """Handle the station sensors device selection step."""
+        if user_input is not None:
+            self._sensor_data.update(user_input)
+
+            # If wired tracker is enabled, proceed to wired tracker configuration
+            if self._sensor_data.get(CONF_ENABLE_WIRED_TRACKER, False):
+                return await self.async_step_wired_tracker_config()
+
+            # If service controls are enabled, proceed to services selection
+            if self._sensor_data.get(CONF_ENABLE_SERVICE_CONTROLS, False):
+                return await self.async_step_services()
+
+            return await self.async_step_timeouts()
+
+        # Fetch currently connected devices for checkboxes
+        if not self._available_sta_devices:
+            self._available_sta_devices = await get_connected_wifi_devices(self.hass, self._connection_data)
+
+        sta_sensors_schema = vol.Schema(
+            {
+                vol.Required(
+                    CONF_SELECT_ALL_STA,
+                    default=DEFAULT_SELECT_ALL_STA,
+                ): cv.boolean,
+                vol.Optional(
+                    CONF_SELECTED_STA,
+                    default=DEFAULT_SELECTED_STA,
+                ): cv.multi_select({mac: name for mac, name in self._available_sta_devices.items()}),
+            }
+        )
+
+        return self.async_show_form(
+            step_id="sta_sensors_config",
+            data_schema=sta_sensors_schema,
             description_placeholders={"host": self._connection_data[CONF_HOST]},
         )
 
@@ -445,6 +583,8 @@ class OpenwrtUbusOptionsFlow(OptionsFlow):
         """Initialize options flow."""
         super().__init__()
         self._available_services: list[str] = []
+        self._available_sta_devices: dict[str, str] = {}
+        self._temp_data: dict[str, Any] = {}
 
     async def async_step_init(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
         """Manage the options."""
@@ -488,14 +628,13 @@ class OpenwrtUbusOptionsFlow(OptionsFlow):
             # Get current data and merge with new options
             new_data = dict(self.config_entry.data)
             new_data.update(user_input)
+            self._temp_data = user_input
 
-            # Update the config entry with new data
-            self.hass.config_entries.async_update_entry(self.config_entry, data=new_data)
+            # If sta sensors enabled, proceed to selection config
+            if user_input.get(CONF_ENABLE_STA_SENSORS, DEFAULT_ENABLE_STA_SENSORS):
+                return await self.async_step_sta_sensors_config()
 
-            # Reload the integration to apply changes
-            await self.hass.config_entries.async_reload(self.config_entry.entry_id)
-
-            return self.async_create_entry(title="", data={})
+            return await self._update_and_reload(user_input)
 
         # Create form with all configurable options
         current_data = self.config_entry.data
@@ -534,6 +673,10 @@ class OpenwrtUbusOptionsFlow(OptionsFlow):
                 vol.Optional(
                     CONF_ENABLE_STA_SENSORS,
                     default=current_data.get(CONF_ENABLE_STA_SENSORS, DEFAULT_ENABLE_STA_SENSORS),
+                ): bool,
+                vol.Optional(
+                    CONF_SELECT_ALL_STA,
+                    default=current_data.get(CONF_SELECT_ALL_STA, DEFAULT_SELECT_ALL_STA),
                 ): bool,
                 vol.Optional(
                     CONF_ENABLE_AP_SENSORS,
@@ -666,6 +809,50 @@ class OpenwrtUbusOptionsFlow(OptionsFlow):
                 "services_count": str(len(self._available_services)) if self._available_services else "0",
             },
         )
+
+    async def async_step_sta_sensors_config(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
+        """Handle station sensors device selection in the options flow."""
+        if user_input is not None:
+            config_data = {**self._temp_data, **user_input}
+            return await self._update_and_reload(config_data)
+
+        # Fetch currently connected devices
+        if not self._available_sta_devices:
+            self._available_sta_devices = await get_connected_wifi_devices(self.hass, self.config_entry.data)
+
+        # Include previously selected offline devices so they can be toggled off
+        current_selected = self.config_entry.data.get(CONF_SELECTED_STA, [])
+        for mac in current_selected:
+            if mac not in self._available_sta_devices:
+                self._available_sta_devices[mac] = f"Offline Device ({mac})"
+
+        current_data = self.config_entry.data
+        sta_sensors_schema = vol.Schema(
+            {
+                vol.Required(
+                    CONF_SELECT_ALL_STA,
+                    default=current_data.get(CONF_SELECT_ALL_STA, DEFAULT_SELECT_ALL_STA),
+                ): cv.boolean,
+                vol.Optional(
+                    CONF_SELECTED_STA,
+                    default=current_selected,
+                ): cv.multi_select({mac: name for mac, name in self._available_sta_devices.items()}),
+            }
+        )
+
+        return self.async_show_form(
+            step_id="sta_sensors_config",
+            data_schema=sta_sensors_schema,
+            description_placeholders={"host": self.config_entry.data[CONF_HOST]},
+        )
+
+    async def _update_and_reload(self, user_input: dict[str, Any]) -> ConfigFlowResult:
+        """Persist options and reload the integration."""
+        new_data = dict(self.config_entry.data)
+        new_data.update(user_input)
+        self.hass.config_entries.async_update_entry(self.config_entry, data=new_data)
+        await self.hass.config_entries.async_reload(self.config_entry.entry_id)
+        return self.async_create_entry(title="", data={})
 
 
 class CannotConnect(HomeAssistantError):

--- a/custom_components/openwrt_ubus/const.py
+++ b/custom_components/openwrt_ubus/const.py
@@ -39,6 +39,9 @@ CONF_WIRED_TRACKER_INTERFACES = "wired_tracker_interfaces"
 # Wireless device tracker configuration
 CONF_ENABLE_WIRELESS_TRACKERS = "enable_wireless_trackers"
 CONF_WIRELESS_TRACKER_WHITELIST = "wireless_tracker_whitelist"
+# STA sensor selection
+CONF_SELECT_ALL_STA = "select_all_sta"
+CONF_SELECTED_STA = "selected_sta"
 
 # Timeout configuration
 CONF_SYSTEM_SENSOR_TIMEOUT = "system_sensor_timeout"
@@ -78,6 +81,8 @@ DEFAULT_WIRED_TRACKER_NAME_PRIORITY = "ipv4"  # Options: ipv4, ipv6, mac
 DEFAULT_WIRED_TRACKER_WHITELIST = []  # Empty list means no filtering
 DEFAULT_WIRED_TRACKER_INTERFACES = []  # Empty list means no interface filtering
 DEFAULT_ENABLE_WIRELESS_TRACKERS = False
+DEFAULT_SELECT_ALL_STA = False
+DEFAULT_SELECTED_STA = []  # Empty list means no devices selected (only matters when select_all_sta is False)
 
 # Consider home configuration
 CONF_CONSIDER_HOME = "consider_home"

--- a/custom_components/openwrt_ubus/sensors/sta_sensor.py
+++ b/custom_components/openwrt_ubus/sensors/sta_sensor.py
@@ -30,6 +30,10 @@ from ..const import (
     DEFAULT_STA_SENSOR_TIMEOUT,
     CONF_TRACKING_METHOD,
     DEFAULT_TRACKING_METHOD,
+    CONF_SELECT_ALL_STA,
+    CONF_SELECTED_STA,
+    DEFAULT_SELECT_ALL_STA,
+    DEFAULT_SELECTED_STA,
 )
 from ..shared_data_manager import SharedDataUpdateCoordinator
 
@@ -429,6 +433,16 @@ async def async_setup_entry(
     # Get tracking method from configuration
     tracking_method = entry.data.get(CONF_TRACKING_METHOD, DEFAULT_TRACKING_METHOD)
 
+    # Get STA sensor filter configuration
+    select_all_sta = entry.options.get(
+        CONF_SELECT_ALL_STA,
+        entry.data.get(CONF_SELECT_ALL_STA, DEFAULT_SELECT_ALL_STA),
+    )
+    selected_sta = entry.options.get(
+        CONF_SELECTED_STA,
+        entry.data.get(CONF_SELECTED_STA, DEFAULT_SELECTED_STA),
+    )
+
     # Migrate sensor unique_ids if needed
     await _migrate_sta_sensor_unique_ids(hass, entry, tracking_method)
 
@@ -465,6 +479,10 @@ async def async_setup_entry(
 
         device_stats = coordinator.data["device_statistics"]
         current_devices = set(device_stats.keys())
+
+        # Filter enabled devices
+        if not select_all_sta:
+            current_devices = {mac for mac in current_devices if mac in selected_sta}
 
         # Handle new devices
         new_devices = current_devices - coordinator.known_devices
@@ -539,6 +557,10 @@ async def async_setup_entry(
     if coordinator.data and coordinator.data.get("device_statistics"):
         device_stats = coordinator.data["device_statistics"]
         for mac_address in device_stats:
+            # Filter enabled devices
+            if not select_all_sta and mac_address not in selected_sta:
+                continue
+
             coordinator.known_devices.add(mac_address)
             device_data = device_stats[mac_address]
 

--- a/custom_components/openwrt_ubus/strings.json
+++ b/custom_components/openwrt_ubus/strings.json
@@ -24,7 +24,7 @@
         "data": {
           "enable_system_sensors": "Enable System Sensors",
           "enable_qmodem_sensors": "Enable QModem Sensors",
-          "enable_sta_sensors": "Enable Station (WiFi Device) Sensors",
+          "enable_sta_sensors": "Enable Station (WiFi Device) Sensors (requires iwinfo)",
           "enable_ap_sensors": "Enable Access Point Sensors",
           "enable_eth_sensors": "Enable Network Interface Sensors",
           "enable_service_controls": "Enable Service Controls",
@@ -38,6 +38,14 @@
         "description": "Configure wireless device tracking filters for {host}. Leave the whitelist empty to track all connected WiFi devices.",
         "data": {
           "wireless_tracker_whitelist": "Whitelist (comma-separated IP/MAC prefixes)"
+        }
+      },
+      "sta_sensors_config": {
+        "title": "OpenWrt ubus - Station Sensor Device Selection",
+        "description": "Select which WiFi devices should have sensor entities created. Note: This list only shows devices visible via iwinfo. If the list is empty, ensure iwinfo is installed and at least one device is connected.\n\nHost: {host}",
+        "data": {
+          "select_all_sta": "Track all connected stations (no filter)",
+          "selected_sta": "Devices to Track"
         }
       },
       "wired_tracker_config": {
@@ -93,7 +101,8 @@
           "dhcp_software": "DHCP Software",
           "enable_system_sensors": "Enable System Sensors",
           "enable_qmodem_sensors": "Enable QModem Sensors",
-          "enable_sta_sensors": "Enable Station (WiFi Device) Sensors",
+          "enable_sta_sensors": "Enable Station (WiFi Device) Sensors (requires iwinfo)",
+          "select_all_sta": "Track all connected stations (no filter)",
           "enable_ap_sensors": "Enable Access Point Sensors",
           "enable_eth_sensors": "Enable Network Interface Sensors",
           "enable_service_controls": "Enable Service Controls",
@@ -122,7 +131,8 @@
           "dhcp_software": "Software used to get DHCP lease information",
           "enable_system_sensors": "Monitor router system information (uptime, memory, load)",
           "enable_qmodem_sensors": "Monitor cellular modem information (if available)",
-          "enable_sta_sensors": "Monitor connected WiFi devices and their statistics",
+          "enable_sta_sensors": "Monitor connected WiFi devices and their statistics (requires iwinfo)",
+          "select_all_sta": "When enabled, sensors will be created for ALL connected devices without filtering",
           "enable_ap_sensors": "Monitor access point interface information (WiFi network details)",
           "enable_eth_sensors": "Monitor network interface statistics",
           "enable_device_kick_buttons": "Enable buttons to disconnect devices from Access Points (requires hostapd)",
@@ -136,6 +146,14 @@
           "ap_sensor_timeout": "How often to update access point data (30-600 seconds)",
           "tracking_method": "Tracking method for devices: 'uniqueid' uses MAC address only (device roams between APs), 'combined' uses AP+MAC (separate entities per AP)",
           "consider_home": "Time in seconds to keep a device as 'home' after it was last seen (0-1800). Set to 0 to disable. Useful for devices that temporarily disconnect during WiFi roaming"
+        }
+      },
+      "sta_sensors_config": {
+        "title": "OpenWrt ubus - Station Sensor Device Selection",
+        "description": "Select which WiFi devices should have sensor entities created. Note: This list only shows devices visible via iwinfo. If the list is empty, ensure iwinfo is installed and at least one device is connected.\n\nHost: {host}",
+        "data": {
+          "select_all_sta": "Track all connected stations (no filter)",
+          "selected_sta": "Devices to Track"
         }
       }
     }

--- a/custom_components/openwrt_ubus/translations/en.json
+++ b/custom_components/openwrt_ubus/translations/en.json
@@ -24,7 +24,7 @@
         "data": {
           "enable_system_sensors": "Enable System Sensors",
           "enable_qmodem_sensors": "Enable QModem Sensors",
-          "enable_sta_sensors": "Enable Station (WiFi Device) Sensors",
+          "enable_sta_sensors": "Enable Station (WiFi Device) Sensors (requires iwinfo)",
           "enable_ap_sensors": "Enable Access Point Sensors",
           "enable_eth_sensors": "Enable Network Interface Sensors",
           "enable_mwan3_sensors": "Enable mwan3 Sensors (if mwan3 is installed)",
@@ -39,6 +39,14 @@
         "description": "Configure wireless device tracking filters for {host}. Leave the whitelist empty to track all connected WiFi devices.",
         "data": {
           "wireless_tracker_whitelist": "Whitelist (comma-separated IP/MAC prefixes)"
+        }
+      },
+      "sta_sensors_config": {
+        "title": "OpenWrt ubus - Station Sensor Device Selection",
+        "description": "Select which WiFi devices should have sensor entities created. Note: This list only shows devices visible via iwinfo. If the list is empty, ensure iwinfo is installed and at least one device is connected.\n\nHost: {host}",
+        "data": {
+          "select_all_sta": "Track all connected stations (no filter)",
+          "selected_sta": "Devices to Track"
         }
       },
       "services": {
@@ -86,7 +94,8 @@
           "dhcp_software": "DHCP Software",
           "enable_system_sensors": "Enable System Sensors",
           "enable_qmodem_sensors": "Enable QModem Sensors",
-          "enable_sta_sensors": "Enable Station (WiFi Device) Sensors",
+          "enable_sta_sensors": "Enable Station (WiFi Device) Sensors (requires iwinfo)",
+          "select_all_sta": "Track all connected stations (no filter)",
           "enable_ap_sensors": "Enable Access Point Sensors",
           "enable_eth_sensors": "Enable Network Interface Sensors",
           "enable_mwan3_sensors": "Enable mwan3 Sensors (if mwan3 is installed)",
@@ -115,7 +124,8 @@
           "dhcp_software": "Software used to get DHCP lease information",
           "enable_system_sensors": "Monitor router system information (uptime, memory, load)",
           "enable_qmodem_sensors": "Monitor cellular modem information (if available)",
-          "enable_sta_sensors": "Monitor connected WiFi devices and their statistics",
+          "enable_sta_sensors": "Monitor connected WiFi devices and their statistics (requires iwinfo)",
+          "select_all_sta": "When enabled, sensors will be created for ALL connected devices without filtering",
           "enable_ap_sensors": "Monitor access point interface information (WiFi network details)",
           "enable_eth_sensors": "Monitor network interface statistics",
           "enable_device_kick_buttons": "Enable buttons to disconnect devices from Access Points (requires hostapd)",
@@ -129,6 +139,14 @@
           "tracking_method": "Tracking method for devices: 'uniqueid' uses MAC address only (device roams between APs), 'combined' uses AP+MAC (separate entities per AP)",
           "mwan3_sensor_timeout": "How often to update mwan3 status data (30-600 seconds)",
           "enable_mwan3_sensors": "Monitor mwan3 multi-WAN load balancing status"
+        }
+      },
+      "sta_sensors_config": {
+        "title": "OpenWrt ubus - Station Sensor Device Selection",
+        "description": "Select which WiFi devices should have sensor entities created. Note: This list only shows devices visible via iwinfo. If the list is empty, ensure iwinfo is installed and at least one device is connected.\n\nHost: {host}",
+        "data": {
+          "select_all_sta": "Track all connected stations (no filter)",
+          "selected_sta": "Devices to Track"
         }
       }
     }


### PR DESCRIPTION
Adds a configuration sub-step to select which connected WiFi stations should have Home Assistant sensor entities created, preventing entity bloat when many devices connect.

- const.py: add CONF_SELECT_ALL_STA, CONF_SELECTED_STA, DEFAULT_SELECT_ALL_STA, DEFAULT_SELECTED_STA
- config_flow.py: extend create_ubus_from_config to return ExtendedUbus; add get_connected_wifi_devices() to resolve MACs to hostnames via /etc/ethers and DHCP leases; add async_step_sta_sensors_config to both ConfigFlow and OptionsFlow; navigate sensors → sta_sensors_config when sta sensors are enabled; add _update_and_reload() helper to options flow; add select_all_sta field to options init schema
- sensors/sta_sensor.py: gate device sensor creation behind select_all_sta / selected_sta filter
- strings.json, translations/en.json: add sta_sensors_config step translations for both config and options flows; mark enable_sta_sensors as '(requires iwinfo)'