### PR TITLE
fix: show stale saved services in options dialog so they can be deselected

### DIFF
--- a/custom_components/openwrt_ubus/config_flow.py
+++ b/custom_components/openwrt_ubus/config_flow.py
@@ -795,14 +795,21 @@ class OpenwrtUbusOptionsFlow(OptionsFlow):
         if not self._available_services and not errors:
             errors["base"] = "no_services_found"
 
-        # Create multi-select schema for services
+        # Create multi-select schema for services.
+        # Include previously-saved services that are no longer on the router so
+        # the user can deselect them (avoids "not a valid option" errors).
         current_services = self.config_entry.data.get(CONF_SELECTED_SERVICES, [])
+        options_dict = {service: service for service in (self._available_services or [])}
+        for svc in current_services:
+            if svc not in options_dict:
+                options_dict[svc] = f"{svc} (not found on router)"
+
         services_schema = vol.Schema({})
-        if self._available_services:
+        if options_dict:
             services_schema = vol.Schema(
                 {
                     vol.Optional(CONF_SELECTED_SERVICES, default=current_services): cv.multi_select(
-                        {service: service for service in self._available_services}
+                        options_dict
                     ),
                 }
             )


### PR DESCRIPTION
If a service was previously selected but has since been removed from the router (e.g. adblock uninstalled), the options flow re-configuration dialog would fail with "not a valid option" because the saved service was no longer in the dynamically-fetched list.

Fix: merge previously-saved services that are missing from the current router list into the multi-select options dict, labelled "<service> (not found on router)". They arrive pre-checked, the user can uncheck them and save — removing them from the config entry cleanly.

This mirrors the same pattern already used for offline STA sensor devices in async_step_sta_sensors_config.