### PR TITLE
fix: avoid double hostapd. prefix when kicking devices

### DIFF
--- a/custom_components/openwrt_ubus/buttons/device_kick_button.py
+++ b/custom_components/openwrt_ubus/buttons/device_kick_button.py
@@ -540,7 +540,7 @@ class DeviceKickButton(CoordinatorEntity[SharedDataUpdateCoordinator], ButtonEnt
             "router": self._host,
             "ap_device": ap_device,
             "ap_ssid": ap_ssid,
-            "hostapd_interface": f"hostapd.{ap_device}",
+            "hostapd_interface": ap_device if ap_device.startswith("hostapd.") else f"hostapd.{ap_device}",
         }
 
     async def async_press(self) -> None:
@@ -555,7 +555,7 @@ class DeviceKickButton(CoordinatorEntity[SharedDataUpdateCoordinator], ButtonEnt
             if not ap_device:
                 raise HomeAssistantError(f"Cannot kick device {hostname}: no AP information available")
 
-            hostapd_interface = f"hostapd.{ap_device}"
+            hostapd_interface = ap_device if ap_device.startswith("hostapd.") else f"hostapd.{ap_device}"
 
             _LOGGER.info(
                 "Kicking device %s (%s) from %s/%s (%s)",


### PR DESCRIPTION
## Summary

- When using the **hostapd** tracking method, `ap_device` values returned by ubus already carry the `hostapd.` prefix (e.g. `hostapd.phy1-ap6`).
- `async_press()` and `extra_state_attributes()` unconditionally prepended `hostapd.` again, producing `hostapd.hostapd.phy1-ap6` — an interface that doesn't exist on the router.
- Every "Kick * from *" button press failed with: `API call failed for hostapd.hostapd.phy1-ap6.del_client: Object not found (code: -32000)`.

The button **creation path** (lines 224–227) already had the correct guard (`if ap_device.startswith("hostapd.")`); this PR applies the same check in the two places that were missing it.

## Test plan

- [x] Confirm kick buttons work when the router uses the hostapd tracking method (AP interfaces reported as `hostapd.phyX-apY`)
- [ ] Confirm kick buttons still work when using the iwinfo tracking method (AP interfaces reported without prefix, e.g. `phyX-apY`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)