### PR TITLE
Exclude raw_data attribute from the recorder

### DIFF
--- a/custom_components/openwrt_ubus/sensors/qmodem_sensor.py
+++ b/custom_components/openwrt_ubus/sensors/qmodem_sensor.py
@@ -239,6 +239,11 @@ async def async_setup_entry(
 class QModemSensor(CoordinatorEntity, SensorEntity):
     """Representation of a QModem sensor."""
 
+    # raw_data carries the full modem dump and changes every poll. Keep it
+    # live for debugging but never record it, otherwise it forces a new state
+    # row + unique attribute blob every update.
+    _unrecorded_attributes = frozenset({"raw_data"})
+
     def __init__(
         self,
         coordinator: SharedDataUpdateCoordinator,

--- a/custom_components/openwrt_ubus/sensors/system_sensor.py
+++ b/custom_components/openwrt_ubus/sensors/system_sensor.py
@@ -299,6 +299,11 @@ class SystemInfoCoordinator(DataUpdateCoordinator):
 class SystemInfoSensor(CoordinatorEntity, SensorEntity):
     """Representation of a system information sensor."""
 
+    # raw_data carries the full coordinator dump and changes every poll
+    # (uptime, /proc/stat). Keep it live for debugging but never record it,
+    # otherwise it forces a new state row + unique attribute blob every update.
+    _unrecorded_attributes = frozenset({"raw_data"})
+
     def __init__(
         self,
         coordinator: SharedDataUpdateCoordinator,


### PR DESCRIPTION
The `SystemInfoSensor` and `QModemSensor` entities attach the full coordinator/modem dump to their state attributes as `raw_data` ("for debugging"). That payload changes on essentially every poll — it includes things like uptime and `/proc/stat` counters — and the same ~2 KB blob is duplicated across every sensor that shares a coordinator.

Because Home Assistant writes a new `states` row whenever **state _or_ attributes** change, recording `raw_data` has two costs:

1. It defeats the recorder’s attribute de-duplication (every poll produces a unique `state_attributes` row).
2. It forces a new `states` row every poll for **every** system/modem sensor, even when the actual sensor value is unchanged.

In a real-world setup this was the single largest driver of recorder database growth (multiple GB over the default 10-day retention from just a few routers).

### Fix

Mark `raw_data` as an [unrecorded attribute](https://developers.home-assistant.io/docs/core/entity/#excluding-state-attributes-from-recording) on both sensor classes:

```python
_unrecorded_attributes = frozenset({"raw_data"})
```

The attribute stays fully live — it is still visible in Developer Tools → States, templates, and the UI — it is simply never persisted to the recorder. No behavior change beyond recorder storage.

Minimal: 2 files, +10 lines, no logic changes.


TL;DR:

On my HA instance it made the HA DB grow quite substancially over time:

<img width="861" height="472" alt="image" src="https://github.com/user-attachments/assets/aedb5368-98c1-4f29-9394-cbe265703fc1" />
